### PR TITLE
Update Stream connectors to work with version 3

### DIFF
--- a/class/MainWPClientReport.class.php
+++ b/class/MainWPClientReport.class.php
@@ -17,20 +17,29 @@ class MainWPClientReport
     }
         
     public static function  init() {                
-        add_filter('wp_stream_connectors', array('MainWPClientReport', 'init_stream_connectors'), 10, 1);   
-        add_filter('mainwp_client_reports_connectors', array('MainWPClientReport', 'init_connectors'), 10, 1);   
+        add_filter('wp_stream_connectors', array('MainWPClientReport', 'init_stream_connectors'), 10, 1);
+        add_filter('mainwp_client_reports_connectors', array('MainWPClientReport', 'init_connectors'), 10, 1);
     }
         
     public static function init_stream_connectors($classes) {
         $connectors = array(
             'Backups',
-            'Sucuri',                  
-        );      
-        
-        foreach ( $connectors as $connector ) {                
-                $class     = "MainWPStreamConnector$connector";
+            'Sucuri',
+        );
+
+        foreach ( $connectors as $connector ) {
+            $class_name = "MainWPStreamConnector$connector";
+            if ( ! class_exists( $class_name ) ) {
+                continue;
+            }
+            $class = new $class_name();
+            if ( ! method_exists( $class, 'is_dependency_satisfied' ) ) {
+                continue;
+            }
+            if ( $class->is_dependency_satisfied() ) {
                 $classes[] = $class;
-        }          
+            }
+        }
         return $classes;
     }
     

--- a/class/MainWPStreamConnectorBackups.class.php
+++ b/class/MainWPStreamConnectorBackups.class.php
@@ -1,6 +1,6 @@
 <?php
-if (class_exists('WP_Stream_Connector')) {
-    class MainWPStreamConnectorBackups extends WP_Stream_Connector   
+if (class_exists('WP_Stream\Connector')) {
+    class MainWPStreamConnectorBackups extends WP_Stream\Connector
     {   
 
 	/**
@@ -8,14 +8,14 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @var string
 	 */
-	public static $name = 'mainwp_backups';
+	public $name = 'mainwp_backups';
 
 	/**
 	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
-	public static $actions = array(
+	public $actions = array(
             'mainwp_backup',		
 	);
 
@@ -24,7 +24,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return string Translated connector label
 	 */
-	public static function get_label() {
+	public function get_label() {
             return __( 'MainWP Backups', 'default' );                
 	}
 
@@ -33,7 +33,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return array Action label translations
 	 */
-	public static function get_action_labels() {
+	public function get_action_labels() {
             return array(
                 'mainwp_backup'    => __( 'Backup', 'default' ),			
             );
@@ -44,7 +44,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return array Context label translations
 	 */
-	public static function get_context_labels() {
+	public function get_context_labels() {
             return array(
                 'mainwp_backups' => __( 'MainWP Backups', 'mainwp-child' ),
             );
@@ -58,18 +58,19 @@ if (class_exists('WP_Stream_Connector')) {
 	 * @param  int   $record     Stream record
 	 * @return array             Action links
 	 */
-	public static function action_links( $links, $record ) {
+	public function action_links( $links, $record ) {
             if (isset($record->object_id)) {
             }
             return $links;
 	}
 
-        public static function callback_mainwp_backup($destination, $message, $size, $status, $type) {                                                
-            self::log(
+        public function callback_mainwp_backup($destination, $message, $size, $status, $type) {
+            $this->log(
                 $message,
                 compact('destination', 'status', 'type', 'size'),
                 0,
-                array( 'mainwp_backups' => 'mainwp_backup' )
+                'mainwp_backups',
+                'mainwp_backup'
             );
         }
     }

--- a/class/MainWPStreamConnectorSucuri.class.php
+++ b/class/MainWPStreamConnectorSucuri.class.php
@@ -1,6 +1,6 @@
 <?php
-if (class_exists('WP_Stream_Connector')) {
-    class MainWPStreamConnectorSucuri extends WP_Stream_Connector   
+if (class_exists('WP_Stream\Connector')) {
+    class MainWPStreamConnectorSucuri extends WP_Stream\Connector
     {   
 
 	/**
@@ -8,14 +8,14 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @var string
 	 */
-	public static $name = 'mainwp_sucuri';
+	public $name = 'mainwp_sucuri';
 
 	/**
 	 * Actions registered for this connector
 	 *
 	 * @var array
 	 */
-	public static $actions = array(
+	public $actions = array(
 		'mainwp_sucuri_scan',		
 	);
 
@@ -24,7 +24,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return string Translated connector label
 	 */
-	public static function get_label() {
+	public function get_label() {
 		return __( 'MainWP Sucuri', 'default' );
 	}
 
@@ -33,7 +33,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return array Action label translations
 	 */
-	public static function get_action_labels() {
+	public function get_action_labels() {
 		return array(
 			'mainwp_sucuri_scan'    => __( 'Scan', 'default' ),			
 		);
@@ -44,7 +44,7 @@ if (class_exists('WP_Stream_Connector')) {
 	 *
 	 * @return array Context label translations
 	 */
-	public static function get_context_labels() {
+	public function get_context_labels() {
 		return array(
 			'mainwp_sucuri' => __( 'MainWP Sucuri', 'default' ),
 		);
@@ -58,14 +58,14 @@ if (class_exists('WP_Stream_Connector')) {
 	 * @param  int   $record     Stream record
 	 * @return array             Action links
 	 */
-	public static function action_links( $links, $record ) {
+	public function action_links( $links, $record ) {
 		if ( isset($record->object_id )) {
 			
 		}
 		return $links;
 	}
 
-        public static function callback_mainwp_sucuri_scan($data, $scan_status) {
+        public function callback_mainwp_sucuri_scan($data, $scan_status) {
             $message = "";            
             if ($scan_status == "success") {
                 $message = __("Sucuri scan success", "mainwp-child");                
@@ -81,11 +81,12 @@ if (class_exists('WP_Stream_Connector')) {
                 $status = isset($scan_result['status']) ? $scan_result['status'] : "";
                 $webtrust = isset($scan_result['webtrust']) ? $scan_result['webtrust'] : "";
             }
-            self::log(
+            $this->log(
                 $message,
                 compact('scan_status', 'status', 'webtrust'),
                 0,
-                array( 'mainwp_sucuri' => 'mainwp_sucuri_scan' )
+                'mainwp_sucuri',
+                'mainwp_sucuri_scan'
             );                        
         }
     }


### PR DESCRIPTION
This resolves a conflict which Stream users were seeing when they updated Stream 3, because your existing connectors aren't compatible with Stream 3.

I haven't touched the custom connectors which were written for the MainWP_Stream class, which is a fork of Stream version 1.