### PR TITLE
fix typo "forbidden"

### DIFF
--- a/class/class-mainwp-security.php
+++ b/class/class-mainwp-security.php
@@ -54,7 +54,7 @@ class MainWP_Security {
 				$h = fopen( $file, 'w' );
 				fwrite( $h, '<?php ' . "\n" );
 				fwrite( $h, "header(\$_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden' );" . "\n" );
-				fwrite( $h, "die( '403 Fordibben' );" . "\n" );
+				fwrite( $h, "die( '403 Forbidden' );" . "\n" );
 				fclose( $h );
 			}
 		}


### PR DESCRIPTION
I fixed a typo in  class/class-mainwp-security.php to make sure, no attacker/spider/bot detects via this typo that a website uses MainWP Child plugin