### PR TITLE
Don't override the PHP error settings as they might be set by other plugins

### DIFF
--- a/class/class-mainwp-child.php
+++ b/class/class-mainwp-child.php
@@ -3,9 +3,6 @@ if ( defined( 'MAINWP_DEBUG' ) && MAINWP_DEBUG === TRUE ) {
 	@error_reporting( E_ALL );
 	@ini_set( 'display_errors', TRUE );
 	@ini_set( 'display_startup_errors', TRUE );
-} else {
-	@ini_set( 'display_errors', FALSE );
-	@error_reporting( 0 );
 }
 
 define( 'MAINWP_CHILD_NR_OF_COMMENTS', 50 );


### PR DESCRIPTION
I had a  mysterious issue today where I couldn't get PHP errors to show on a project. Turns out the MainWP Child is setting options for hiding PHP error messages by default. This is not good behaviour.

**Don't touch any PHP options** unless the user specifically has requested that (like by setting `MAINWP_DEBUG`).