### PR TITLE
Fix openssl version check

### DIFF
--- a/class/class-mainwp-child-server-information.php
+++ b/class/class-mainwp-child-server-information.php
@@ -697,11 +697,16 @@ class MainWP_Child_Server_Information extends MainWP_Child_Server_Information_Ba
 		self::render_row_sec( 'cURL Timeout', '>=', '300', 'get_curl_timeout', 'seconds', '=', '0' );
 		if ( function_exists( 'curl_version' ) ) {
 			self::render_row_sec( 'cURL Version', '>=', '7.18.1', 'get_curl_version', '', '', null );
-			$openssl_version = 'OpenSSL/1.1.0';
+
+			$openssl_version = array(
+				'version_text' => 'OpenSSL/1.1.0',
+				'version_number' => 0x1010000f
+			);
+
 			self::render_row_sec(
 				'cURL SSL Version',
 				'>=',
-				$openssl_version,
+				$openssl_version['version_text'],
 				'get_curl_ssl_version',
 				'',
 				'',

--- a/class/class-mainwp-child-server-information.php
+++ b/class/class-mainwp-child-server-information.php
@@ -699,8 +699,8 @@ class MainWP_Child_Server_Information extends MainWP_Child_Server_Information_Ba
 			self::render_row_sec( 'cURL Version', '>=', '7.18.1', 'get_curl_version', '', '', null );
 
 			$openssl_version = array(
-				'version_text' => 'OpenSSL/1.1.0',
-				'version_number' => 0x1010000f
+				'version_text'   => 'OpenSSL/1.1.0',
+				'version_number' => 0x1010000f,
 			);
 
 			self::render_row_sec(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp-child/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp-child/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix for this reported request: https://wordpress.org/support/topic/false-positive-for-openssl-version/

This was happening because $openssl_version was a string instead of an array as expected from the curlssl check function.

The hex version of OpenSSL 1.1.0 is taken from the source code of the OpenSSL 1.1.0 tag release on github: https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_0

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
