### PR TITLE
Added Post SMTP

### DIFF
--- a/class/class-mainwp-child-callable.php
+++ b/class/class-mainwp-child-callable.php
@@ -97,6 +97,7 @@ class MainWP_Child_Callable {
 		'jetpack_protect'       => 'jetpack_protect',
 		'jetpack_scan'          => 'jetpack_scan',
 		'delete_actions'        => 'delete_actions',
+		'post_smtp'				=> 'post_smtp'
 	);
 
 	/**
@@ -1059,6 +1060,20 @@ class MainWP_Child_Callable {
 		}
 		$information['deactivated'] = true;
 		MainWP_Helper::write( $information );
+	}
+	
+	
+	/**
+	 * Method post_smtp()
+	 *
+	 * Fire off the action() function.
+	 * 
+	 * @uses \MainWP\Child\MainWP_Child_Post_SMTP::action()
+	 */
+	public function post_smtp() {
+		
+		MainWP_Child_Post_SMTP::get_instance()->action();
+		
 	}
 
 }

--- a/class/class-mainwp-child-post-smtp.php
+++ b/class/class-mainwp-child-post-smtp.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * MainWP Post SMTP
+ *
+ * MainWP Post SMTP extension handler.
+ *
+ * @link https://mainwp.com/extension/post-smtp/
+ * @package MainWP\Child
+ *
+ * Credits
+ *
+ * Plugin-Name: Post SMTP
+ * Plugin-URI: https://www.postmansmtp.com/
+ * Author: Post SMTP
+ * Author URI: https://www.postmansmtp.com/
+ */
+
+namespace MainWP\Child;
+
+/**
+ * Class MainWP_Child_Post_SMTP
+ *
+ * MainWP Post SMTP extension handler.
+ */
+class MainWP_Child_Post_SMTP {
+	
+	private $base_url = false;
+	
+	
+	/**
+	 * Public static variable to hold the single instance of the class.
+	 *
+	 * @var mixed Default null
+	 */
+	public static $instance = null;
+	
+	/**
+	 * Method instance()
+	 *
+	 * Create a public static instance.
+	 *
+	 * @return mixed Class instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+	
+	public function __construct() {
+		
+		$server = get_option( 'mainwp_child_server' );
+
+        if( $server ) {
+            
+			$this->base_url = parse_url( $server, PHP_URL_SCHEME ) . "://" . parse_url( $server, PHP_URL_HOST ) . "/" . 'wp-json/post-smtp-for-mainwp/v1/send-email';
+
+        }
+		
+	}
+	
+	/**
+     * Process email
+     * 
+     * @param string|array $to Array or comma-separated list of email addresses to send message.
+     * @param string $subject Email subject
+     * @param string $message Message contents
+     * @param string|array $headers Optional. Additional headers.
+     * @param string|array $attachments Optional. Files to attach.
+     * @return bool Whether the email contents were sent successfully.
+     * 
+     * @version 1.0
+     */
+	public function process_email( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		
+		$body = array();
+		$pubkey = get_option( 'mainwp_child_pubkey' );
+		$pubkey = $pubkey ? md5( $pubkey ) : '';
+        $request_headers = array(
+            'Site-URL'	=>	site_url( '/' ),
+			'API-Key'	=>	$pubkey
+        );
+		
+		//let's manage attachments
+		if( !empty( $attachments ) && $attachments ) {
+
+			$_attachments = $attachments;
+			$attachments = array();
+			foreach( $_attachments as $attachment ) {
+				
+				$attachments[$attachment] = file_get_contents( $attachment );
+					
+			}
+			
+		}
+			
+		$body = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
+
+        $response = wp_remote_post(
+            $this->base_url,
+            array(
+                'method'	=> 'POST',
+                'body'		=>	$body,
+                'headers'	=>	$request_headers
+            )
+        );
+
+        if( wp_remote_retrieve_body( $response ) ) {
+			
+			return true;
+			
+		}
+
+	}
+	
+	
+	public function action() {
+		
+		$mwp_action = ! empty( $_POST['mwp_action'] ) ? sanitize_text_field( wp_unslash( $_POST['mwp_action'] ) ) : '';
+		switch ( $mwp_action ) {
+			case 'enable_post_smtp':
+				$information = $this->enable_from_main_site();
+				break;
+			case 'disable_post_smtp':
+				$information = $this->disable_from_main_site();
+				break;
+		}
+		
+		MainWP_Helper::write( $information );
+		
+	}
+	
+	
+	public function enable_from_main_site() {
+		
+		return update_option( 'post_smtp_use_from_main_site', '1' );
+		
+	}
+
+	
+	public function disable_from_main_site() {
+		
+		return delete_option( 'post_smtp_use_from_main_site' );
+		
+	}
+}

--- a/class/class-mainwp-child-post-smtp.php
+++ b/class/class-mainwp-child-post-smtp.php
@@ -68,8 +68,6 @@ class MainWP_Child_Post_SMTP {
             
 			$this->base_url = wp_parse_url( $server, PHP_URL_SCHEME ) . "://" . wp_parse_url( $server, PHP_URL_HOST ) . '/wp-json/post-smtp-for-mainwp/v1/send-email';
 
-			$this->base_url = parse_url( $server, PHP_URL_SCHEME ) . '://' . parse_url( $server, PHP_URL_HOST ) . '/' . 'wp-json/post-smtp-for-mainwp/v1/send-email';
-
 		}
 	}
 
@@ -173,9 +171,4 @@ class MainWP_Child_Post_SMTP {
 		
 	}
 
-
-	public function disable_from_main_site() {
-
-		return delete_option( 'post_smtp_use_from_main_site' );
-	}
 }

--- a/class/class-mainwp-child-post-smtp.php
+++ b/class/class-mainwp-child-post-smtp.php
@@ -23,7 +23,12 @@ namespace MainWP\Child;
  * MainWP Post SMTP extension handler.
  */
 class MainWP_Child_Post_SMTP {
-	
+
+	/**
+	 * Base URL
+	 * 
+	 * @var string
+	 */
 	private $base_url = false;
 	
 	
@@ -49,13 +54,19 @@ class MainWP_Child_Post_SMTP {
 		return self::$instance;
 	}
 	
+
+	/**
+	 * Constructor
+	 * 
+	 * @version 1.0
+	 */
 	public function __construct() {
 		
 		$server = get_option( 'mainwp_child_server' );
 
         if( $server ) {
             
-			$this->base_url = parse_url( $server, PHP_URL_SCHEME ) . "://" . parse_url( $server, PHP_URL_HOST ) . "/" . 'wp-json/post-smtp-for-mainwp/v1/send-email';
+			$this->base_url = wp_parse_url( $server, PHP_URL_SCHEME ) . "://" . wp_parse_url( $server, PHP_URL_HOST ) . '/wp-json/post-smtp-for-mainwp/v1/send-email';
 
         }
 		
@@ -65,8 +76,8 @@ class MainWP_Child_Post_SMTP {
      * Process email
      * 
      * @param string|array $to Array or comma-separated list of email addresses to send message.
-     * @param string $subject Email subject
-     * @param string $message Message contents
+     * @param string $subject Email subject.
+     * @param string $message Message contents.
      * @param string|array $headers Optional. Additional headers.
      * @param string|array $attachments Optional. Files to attach.
      * @return bool Whether the email contents were sent successfully.
@@ -83,14 +94,14 @@ class MainWP_Child_Post_SMTP {
 			'API-Key'	=>	$pubkey
         );
 		
-		//let's manage attachments
+		//let's manage attachments.
 		if( !empty( $attachments ) && $attachments ) {
 
 			$_attachments = $attachments;
 			$attachments = array();
 			foreach( $_attachments as $attachment ) {
 				
-				$attachments[$attachment] = file_get_contents( $attachment );
+				$attachments[$attachment] = wp_remote_get( $attachment );
 					
 			}
 			
@@ -116,6 +127,11 @@ class MainWP_Child_Post_SMTP {
 	}
 	
 	
+	/**
+	 * Action
+	 * 
+	 * @version 1.0
+	 */
 	public function action() {
 		
 		$mwp_action = ! empty( $_POST['mwp_action'] ) ? sanitize_text_field( wp_unslash( $_POST['mwp_action'] ) ) : '';
@@ -133,6 +149,12 @@ class MainWP_Child_Post_SMTP {
 	}
 	
 	
+	/**
+	 * Enable from main site
+	 * 
+	 * @return bool
+	 * @version 1.0
+	 */
 	public function enable_from_main_site() {
 		
 		return update_option( 'post_smtp_use_from_main_site', '1' );
@@ -140,6 +162,12 @@ class MainWP_Child_Post_SMTP {
 	}
 
 	
+	/**
+	 * Disable from main site
+	 * 
+	 * @return bool
+	 * @version 1.0
+	 */
 	public function disable_from_main_site() {
 		
 		return delete_option( 'post_smtp_use_from_main_site' );

--- a/class/class-mainwp-child.php
+++ b/class/class-mainwp-child.php
@@ -397,6 +397,7 @@ class MainWP_Child {
 		MainWP_Child_DB_Updater::instance();
 		MainWP_Child_Jetpack_Protect::instance();
 		MainWP_Child_Jetpack_Scan::instance();
+		MainWP_Child_Post_SMTP::get_instance();
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -195,3 +195,22 @@ if ( ! function_exists( 'apply_filters_deprecated' ) ) {
 		return apply_filters_ref_array( $hook_name, $args );
 	}
 }
+
+$post_smtp_enabled = get_option( 'post_smtp_use_from_main_site' );
+if( !function_exists( 'wp_mail' ) && $post_smtp_enabled ) {
+	
+	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		
+		$response = MainWP\Child\MainWP_Child_Post_SMTP::get_instance()->process_email( $to, $subject, $message, $headers, $attachments );
+		
+		if( is_wp_error( $response ) ) {
+        
+			return false;
+
+		}
+
+		return true;
+		
+	}
+	
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -198,7 +198,19 @@ if ( ! function_exists( 'apply_filters_deprecated' ) ) {
 
 $post_smtp_enabled = get_option( 'post_smtp_use_from_main_site' );
 if( !function_exists( 'wp_mail' ) && $post_smtp_enabled ) {
-	
+
+	/**
+     * Overwrite wp_mail function
+     * 
+     * @param string|array $to Array or comma-separated list of email addresses to send message.
+     * @param string $subject Email subject.
+     * @param string $message Message contents.
+     * @param string|array $headers Optional. Additional headers.
+     * @param string|array $attachments Optional. Files to attach.
+     * @return bool Whether the email contents were sent successfully.
+     * 
+     * @version 1.0
+     */
 	function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
 		
 		$response = MainWP\Child\MainWP_Child_Post_SMTP::get_instance()->process_email( $to, $subject, $message, $headers, $attachments );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp-child/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp-child/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Post SMTP a WordPress SMTP Plugin

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Added Post SMTP, user can setup Post SMTP on Main site, and utilize it on all child site, without configuring individually again and again.
Closes # .

### How to test the changes in this Pull Request:

1. Activate and Configure Post SMTP on MainWP Dashboard
2. Go to MainWP Dashboard -> Extensions -> Post SMTP -> Enable Post SMTP on Child sites (From Main Site).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> NEW - Post SMTP