### PR TITLE
Adde AAM child implementation

### DIFF
--- a/class/class-mainwp-child-aam.php
+++ b/class/class-mainwp-child-aam.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * MainWP Child AAM.
+ *
+ * MainWP AAM Extension handler.
+ *
+ * @link https://aamportal.com/integration/mainwp
+ *
+ * @package MainWP\Child
+ *
+ * Credits
+ *
+ * Plugin-Name: Advanced Access Manager
+ * Plugin URI: https://wordpress.org/plugins/advanced-access-manager/
+ * Author: Vasyltech
+ * Author URI: https://vasyltech.com/
+ *
+ * The code is used for the MainWP AAM Extension
+ * Extension URL: https://aamportal.com/integration/mainwp
+ */
+
+namespace MainWP\Child;
+
+use AAM_Service_SecurityAudit;
+
+// phpcs:disable PSR1.Classes.ClassDeclaration, WordPress.WP.AlternativeFunctions -- Required to achieve desired results. Pull requests appreciated.
+
+/**
+ * Class MainWP_Child_Aam
+ *
+ * MainWP Staging Extension handler.
+ */
+class MainWP_Child_Aam {
+
+    /**
+     * Public static variable to hold the single instance of the class.
+     *
+     * @var mixed Default null
+     */
+    public static $instance = null;
+
+    /**
+     * Public variable to hold the information if the WP Staging plugin is installed on the child site.
+     *
+     * @var bool If WP Staging installed, return true, if not, return false.
+     */
+    public $is_plugin_installed = false;
+
+    /**
+     * Public variable to hold the information if the WP Staging plugin is installed on the child site.
+     *
+     * @var string version string.
+     */
+    public $plugin_version = false;
+
+    /**
+     * Create a public static instance of MainWP_Child_Aam.
+     *
+     * @return MainWP_Child_Aam
+     */
+    public static function instance() {
+        if ( null === static::$instance ) {
+            static::$instance = new self();
+        }
+        return static::$instance;
+    }
+
+    /**
+     * MainWP_Child_Aam constructor.
+     *
+     * Run any time class is called.
+     */
+    public function __construct() {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php'; // NOSONAR - WP compatible.
+
+        if ( is_plugin_active( 'advanced-access-manager/aam.php' ) && defined( 'AAM_KEY' ) ) {
+            $this->is_plugin_installed = true;
+        }
+
+        if ( ! $this->is_plugin_installed ) {
+            return;
+        }
+
+        add_filter( 'mainwp_site_sync_others_data', array( $this, 'sync_others_data' ), 10, 2 );
+    }
+
+    /**
+     * Sync others data.
+     *
+     * Get an array of available clones of this Child Sites.
+     *
+     * @param array $information Holder for available clones.
+     * @param array $data Array of existing clones.
+     *
+     * @return array $information An array of available clones.
+     */
+    public function sync_others_data( $information, $data = array() ) {
+        if ( !empty( $data['aam'] ) ) {
+            try {
+                $aam_info = [];
+
+                // Get list of data point we would like to fetch
+                foreach($data['aam'] as $data_point) {
+                    $method = '_get_' . $data_point;
+
+                    if (method_exists( $this, $method )) {
+                        $aam_info[$data_point] = $this->{$method}();
+                    }
+                }
+
+                $information['aam'] = $aam_info;
+            } catch ( MainWP_Exception $e ) {
+                // error!
+            }
+        }
+
+        return $information;
+    }
+
+    /**
+     * Get security audit score
+     *
+     * @return int|null
+     * @access private
+     */
+    private function _get_security_score() {
+        return get_option( AAM_Service_SecurityAudit::DB_SCOPE_OPTION, null );
+    }
+
+    /**
+     * Get report summary
+     *
+     * @return array
+     * @access private
+     */
+    private function _get_issues_summary() {
+        $result = [];
+        $report = get_option( AAM_Service_SecurityAudit::DB_OPTION, [] );
+
+        if (is_array( $report )) {
+            $result = [
+                'error'    => 0,
+                'notice'   => 0,
+                'warning'  => 0,
+                'critical' => 0
+            ];
+
+            foreach($report as $group) {
+                foreach($group['issues'] as $issue) {
+                    $result[$issue['type']]++;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+}

--- a/class/class-mainwp-child.php
+++ b/class/class-mainwp-child.php
@@ -412,6 +412,7 @@ class MainWP_Child {
      * @uses \MainWP\Child\MainWP_Child_Pagespeed::init()
      * @uses \MainWP\Child\MainWP_Child_Links_Checker::init()
      * @uses \MainWP\Child\MainWP_Child_WPvivid_BackupRestore::init()
+     * @uses \MainWP\Child\MainWP_Child_Aam::instance()
      */
     private function parse_init_extensions() {
         MainWP_Child_Branding::instance()->branding_init();
@@ -431,6 +432,7 @@ class MainWP_Child {
         MainWP_Child_DB_Updater::instance();
         MainWP_Child_Jetpack_Protect::instance();
         MainWP_Child_Jetpack_Scan::instance();
+        MainWP_Child_Aam::instance();
         MainWP_Custom_Post_Type::instance();
     }
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request add the child connector for the upcoming MainWP AAM Extension. The first iteration of the extension allows MainWP Dashboard managers to see AAM Security Score information in two places:
- On the list of sites as additional column "AAM Issues" (name of the column is subject to change);

<img width="1155" alt="Screen Shot 2025-02-01 at 8 20 25 PM" src="https://github.com/user-attachments/assets/40d8552b-4e5f-42c9-999a-4994345a1fae" />

- On the site individual page as gauge

<img width="526" alt="Screen Shot 2025-02-01 at 8 21 03 PM" src="https://github.com/user-attachments/assets/71e6b9ba-f150-4113-b9b8-a040212973b7" />

AAM takes a whole new spin when it comes to secure WordPress website from the inside-out and tackles the biggest reason for security incidences these days, which is broken access controls.

To learn more about AAM Security Audit, please refer to [What is AAM security audit and how it works](https://aamportal.com/article/what-is-aam-security-audit-and-how-it-works)

### How to test the changes in this Pull Request:

1. Run site sync on the MainWP Dashboard. The synced AAM data is stored as `aam_sync_data` property inside the `mainwp_wp_options` table for each site separately.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

A good dozen of our clients asked about AAM integration with MainWP. That is why we are eager to have this integration finalized and ready to role. In the next iteration we would love to include some actionable functionality that allows to fix found issues and effectively manage access controls across all sites through MainWP Dashboard.

* [X] Have you written new tests for your changes, as applicable?

At the moment we do not find it necessary as it is very simple and straight to the point functionality.

* [X] Have you successfully run tests with your changes locally?

Yes, we were able to successfully verify that all the necessary information is synced properly.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Introduction integration between MainWP and Advanced Access Manager plugins.
