### PR TITLE
Fix server info base

### DIFF
--- a/class/class-mainwp-child-actions.php
+++ b/class/class-mainwp-child-actions.php
@@ -819,7 +819,7 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
             'extra_info' => $extra_info,
         );
 
-        $created = MainWP_Helper::get_timestamp();
+        $created = time();
 
         $action = (string) $action;
 

--- a/class/class-mainwp-child-actions.php
+++ b/class/class-mainwp-child-actions.php
@@ -613,7 +613,9 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
 
         $info = $update_results['core'][0];
 
-        $old_version  = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        // Get WordPress version using global variable instead of static method call
+        global $wp_version;
+        $old_version  = $wp_version;
         $new_version  = $info->item->version;
         $auto_updated = true;
 
@@ -639,7 +641,9 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
          */
         global $pagenow;
 
-        $old_version  = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        // Get WordPress version using global variable instead of static method call
+        global $wp_version;
+        $old_version  = $wp_version;
         $auto_updated = ( 'update-core.php' !== $pagenow );
 
         if ( $auto_updated ) {

--- a/class/class-mainwp-child-actions.php
+++ b/class/class-mainwp-child-actions.php
@@ -605,7 +605,7 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
      * @return mixed bool|null.
      */
     public function callback_automatic_updates_complete( $update_results ) {
-        global $pagenow, $wp_version;
+        global $pagenow;
 
         if ( ! is_array( $update_results ) || ! isset( $update_results['core'] ) ) {
             return false;
@@ -613,7 +613,7 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
 
         $info = $update_results['core'][0];
 
-        $old_version  = $wp_version;
+        $old_version  = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $new_version  = $info->item->version;
         $auto_updated = true;
 
@@ -636,11 +636,10 @@ class MainWP_Child_Actions { //phpcs:ignore -- NOSONAR - multi method.
          * Global variables.
          *
          * @global string $pagenow Current page.
-         * @global string $wp_version WordPress version.
          */
-        global $pagenow, $wp_version;
+        global $pagenow;
 
-        $old_version  = $wp_version;
+        $old_version  = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $auto_updated = ( 'update-core.php' !== $pagenow );
 
         if ( $auto_updated ) {

--- a/class/class-mainwp-child-back-up-buddy.php
+++ b/class/class-mainwp-child-back-up-buddy.php
@@ -1513,10 +1513,9 @@ class MainWP_Child_Back_Up_Buddy { //phpcs:ignore -- NOSONAR - multi methods.
 
         \pb_backupbuddy::set_status_serial( 'restore' );
 
-        /** @global string $wp_version WordPress version. */
-        global $wp_version;
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
 
-        \pb_backupbuddy::status( 'details', 'BackupBuddy v' . \pb_backupbuddy::settings( 'version' ) . ' using WordPress v' . $wp_version . ' on ' . PHP_OS . '.' );
+        \pb_backupbuddy::status( 'details', 'BackupBuddy v' . \pb_backupbuddy::settings( 'version' ) . ' using WordPress v' . $wp_ver . ' on ' . PHP_OS . '.' );
 
         require_once \pb_backupbuddy::plugin_path() . '/classes/_restoreFiles.php'; // NOSONAR - WP compatible.
 
@@ -3045,12 +3044,11 @@ class MainWP_Child_Back_Up_Buddy { //phpcs:ignore -- NOSONAR - multi methods.
             require_once \pb_backupbuddy::plugin_path() . '/destinations/stash2/init.php'; // NOSONAR - WP compatible.
             require_once \pb_backupbuddy::plugin_path() . '/destinations/live/init.php'; // NOSONAR - WP compatible.
 
-            /** @global string $wp_version WordPress version. */
-            global $wp_version;
+            $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
 
             $itxapi_username = strtolower( $_POST['live_username'] );
             $password_hash   = \iThemes_Credentials::get_password_hash( $itxapi_username, $_POST['live_password'] );
-            $access_token    = \ITXAPI_Helper2::get_access_token( $itxapi_username, $password_hash, site_url(), $wp_version );
+            $access_token    = \ITXAPI_Helper2::get_access_token( $itxapi_username, $password_hash, site_url(), $wp_ver );
 
             $settings = array(
                 'itxapi_username' => $itxapi_username,

--- a/class/class-mainwp-child-plugins-check.php
+++ b/class/class-mainwp-child-plugins-check.php
@@ -346,17 +346,12 @@ class MainWP_Child_Plugins_Check {
         // Get the WordPress current version to be polite in the API call.
         include_once ABSPATH . WPINC . '/version.php'; // NOSONAR - WP compatible.
 
-        /**
-         * The installed version of WordPress.
-         *
-         * @global string $wp_version The installed version of WordPress.
-         */
-        global $wp_version;
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
 
         // General options to be passed to wp_remote_get.
         $options = array(
             'timeout'    => 60 * 60,
-            'user-agent' => 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ),
+            'user-agent' => 'WordPress/' . $wp_ver . '; ' . get_bloginfo( 'url' ),
         );
 
         // The URL for the endpoint.

--- a/class/class-mainwp-child-plugins-check.php
+++ b/class/class-mainwp-child-plugins-check.php
@@ -346,7 +346,9 @@ class MainWP_Child_Plugins_Check {
         // Get the WordPress current version to be polite in the API call.
         include_once ABSPATH . WPINC . '/version.php'; // NOSONAR - WP compatible.
 
-        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        // Get WordPress version using global variable instead of static method call
+        global $wp_version;
+        $wp_ver = $wp_version;
 
         // General options to be passed to wp_remote_get.
         $options = array(

--- a/class/class-mainwp-child-server-information-base.php
+++ b/class/class-mainwp-child-server-information-base.php
@@ -297,7 +297,7 @@ class MainWP_Child_Server_Information_Base { //phpcs:ignore -- NOSONAR - multi m
      *
      * @return string $wp_version Current WordPress version.
      */
-    protected static function get_wordpress_version() {
+    public static function get_wordpress_version() {
 
         /**
          * The installed version of WordPress.
@@ -305,6 +305,10 @@ class MainWP_Child_Server_Information_Base { //phpcs:ignore -- NOSONAR - multi m
          * @global string $wp_version The installed version of WordPress.
          */
         global $wp_version;
+
+        if ( function_exists( '\wp_get_wp_version' ) ) {
+            return \wp_get_wp_version();
+        }
 
         return $wp_version;
     }

--- a/class/class-mainwp-child-stats.php
+++ b/class/class-mainwp-child-stats.php
@@ -104,18 +104,8 @@ class MainWP_Child_Stats { //phpcs:ignore -- NOSONAR - multi methods.
             MainWP_Helper::instance()->error( esc_html__( 'This site already contains a link. Please deactivate and reactivate the MainWP plugin.', 'mainwp-child' ) . $hint );
         }
 
-        /**
-         * The installed version of WordPress.
-         *
-         * @global string $wp_version The installed version of WordPress.
-         *
-         * @uses \MainWP\Child\MainWP_Child::$version
-         * @uses \MainWP\Child\MainWP_Helper::write()
-         */
-        global $wp_version;
-
         $information['version']   = MainWP_Child::$version;
-        $information['wpversion'] = $wp_version;
+        $information['wpversion'] = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $information['wpe']       = MainWP_Helper::is_wp_engine() ? 1 : 0;
         $information['wphost']    = MainWP_Helper::get_wp_host();
         MainWP_Helper::write( $information );
@@ -595,27 +585,15 @@ class MainWP_Child_Stats { //phpcs:ignore -- NOSONAR - multi methods.
      */
     private function stats_get_info( &$information ) {
 
-        /**
-         * The installed version of WordPress.
-         *
-         * @global string $wp_version The installed version of WordPress.
-         *
-         * @uses \MainWP\Child\MainWP_Child::$version
-         * @uses \MainWP\Child\MainWP_Helper::is_wp_engine()
-         * @uses \MainWP\Child\MainWP_Helper::is_ssl_enabled()
-         * @uses \MainWP\Child\MainWP_Helper::update_option()
-         */
-        global $wp_version;
-
         $information['version']   = MainWP_Child::$version;
-        $information['wpversion'] = $wp_version;
+        $information['wpversion'] = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $information['siteurl']   = get_option( 'siteurl' );
         $information['wpe']       = MainWP_Helper::is_wp_engine() ? 1 : 0;
         $information['wphost']    = MainWP_Helper::get_wp_host();
 
         $theme_name               = wp_get_theme()->get( 'Name' );
         $information['site_info'] = array(
-            'wpversion'             => $wp_version,
+            'wpversion'             => MainWP_Child_Server_Information_Base::get_wordpress_version(),
             'debug_mode'            => ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) ? true : false,
             'phpversion'            => phpversion(),
             'child_version'         => MainWP_Child::$version,
@@ -639,13 +617,6 @@ class MainWP_Child_Stats { //phpcs:ignore -- NOSONAR - multi methods.
      */
     public function stats_wp_update() {
 
-        /**
-         * The installed version of WordPress.
-         *
-         * @global string $wp_version The installed version of WordPress.
-         */
-        global $wp_version;
-
         $result = null;
 
         // Check for new versions.
@@ -660,12 +631,14 @@ class MainWP_Child_Stats { //phpcs:ignore -- NOSONAR - multi methods.
 
         $core_updates = get_core_updates();
 
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+
         if ( is_array( $core_updates ) && count( $core_updates ) > 0 ) {
             foreach ( $core_updates as $core_update ) {
                 if ( 'latest' === $core_update->response ) {
                     break;
                 }
-                if ( 'upgrade' === $core_update->response && version_compare( $wp_version, $core_update->current, '<=' ) ) {
+                if ( 'upgrade' === $core_update->response && version_compare( $wp_ver, $core_update->current, '<=' ) ) {
                     $result = $core_update->current;
                 }
             }

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -1139,13 +1139,6 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
      */
     public function upgrade_wp() {
 
-        /**
-         * The installed version of WordPress.
-         *
-         * @global string $wp_version The installed version of WordPress.
-         */
-        global $wp_version;
-
         MainWP_Helper::get_wp_filesystem();
 
         $information = array();
@@ -1222,15 +1215,14 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         // Check for new versions.
         MainWP_System::wp_mainwp_version_check();
 
-        global $wp_version;
-
+        $wp_ver       = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $core_updates = get_core_updates();
         if ( is_array( $core_updates ) && count( $core_updates ) > 0 ) {
             foreach ( $core_updates as $core_update ) {
                 if ( 'latest' === $core_update->response ) {
                     $information['upgrade'] = 'SUCCESS';
-                } elseif ( 'upgrade' === $core_update->response && get_locale() === $core_update->locale && version_compare( $wp_version, $core_update->current, '<=' ) ) {
-                    $old_ver     = $wp_version;
+                } elseif ( 'upgrade' === $core_update->response && get_locale() === $core_update->locale && version_compare( $wp_ver, $core_update->current, '<=' ) ) {
+                    $old_ver     = $wp_ver;
                     $current_ver = $core_update->current;
 
                     // Upgrade!
@@ -1256,8 +1248,8 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
 
             if ( ! isset( $information['upgrade'] ) ) {
                 foreach ( $core_updates as $core_update ) {
-                    if ( 'upgrade' === $core_update->response && version_compare( $wp_version, $core_update->current, '<=' ) ) {
-                        $old_ver     = $wp_version;
+                    if ( 'upgrade' === $core_update->response && version_compare( $wp_ver, $core_update->current, '<=' ) ) {
+                        $old_ver     = $wp_ver;
                         $current_ver = $core_update->current;
                         // Upgrade!
                         $upgrade = false;

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -1215,7 +1215,9 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         // Check for new versions.
         MainWP_System::wp_mainwp_version_check();
 
-        $wp_ver       = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        // Get WordPress version using global variable instead of static method call
+        global $wp_version;
+        $wp_ver       = $wp_version;
         $core_updates = get_core_updates();
         if ( is_array( $core_updates ) && count( $core_updates ) > 0 ) {
             foreach ( $core_updates as $core_update ) {

--- a/class/class-mainwp-child-updraft-plus-backups.php
+++ b/class/class-mainwp-child-updraft-plus-backups.php
@@ -2244,7 +2244,10 @@ class MainWP_Child_Updraft_Plus_Backups { //phpcs:ignore -- NOSONAR - multi meth
          * @global object $wp_filesystem WordPress filesystem.
          * @global object $updraftplus UpdraftPlus object.
          */
-        global $updraftplus, $wp_version;
+        global $updraftplus;
+
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+
 
         include_once ABSPATH . WPINC . '/version.php'; // NOSONAR - WP compatible.
 
@@ -2385,8 +2388,8 @@ class MainWP_Child_Updraft_Plus_Backups { //phpcs:ignore -- NOSONAR - multi meth
                     if ( ! empty( $matches[3] ) ) {
                         $old_wp_version .= substr( $matches[3], 0, strlen( $matches[3] ) - 1 );
                     }
-                    if ( version_compare( $old_wp_version, $wp_version, '>' ) ) {
-                        $warn[] = sprintf( esc_html__( 'You are importing from a newer version of WordPress (%1$s) into an older one (%2$s). There are no guarantees that WordPress can handle this.', 'updraftplus' ), $old_wp_version, $wp_version );
+                    if ( version_compare( $old_wp_version, $wp_ver, '>' ) ) {
+                        $warn[] = sprintf( esc_html__( 'You are importing from a newer version of WordPress (%1$s) into an older one (%2$s). There are no guarantees that WordPress can handle this.', 'updraftplus' ), $old_wp_version, $wp_ver );
                     }
                     if ( preg_match( '/running on PHP (\d+\.\d+)([\s\.])/', $matches[4], $nmatches ) && preg_match( '/^(\d+\.\d+)([\s\.])/', PHP_VERSION, $cmatches ) ) {
                         $old_php_version     = $nmatches[1];

--- a/class/class-mainwp-child-vulnerability-checker.php
+++ b/class/class-mainwp-child-vulnerability-checker.php
@@ -308,7 +308,9 @@ class MainWP_Child_Vulnerability_Checker {
      */
     public function check_wp( $force = false, $service = '' ) {
         $wp_vuln        = get_transient( 'mainwp_vulnche_trans_wp_json' );
-        $wp_ver         = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        // Get WordPress version using global variable instead of static method call
+        global $wp_version;
+        $wp_ver         = $wp_version;
         $number_version = str_replace( '.', '', $wp_ver );
         if ( false === $wp_vuln || $force ) {
             if ( 'nvd_nist' === $service ) {

--- a/class/class-mainwp-child-vulnerability-checker.php
+++ b/class/class-mainwp-child-vulnerability-checker.php
@@ -308,7 +308,7 @@ class MainWP_Child_Vulnerability_Checker {
      */
     public function check_wp( $force = false, $service = '' ) {
         $wp_vuln        = get_transient( 'mainwp_vulnche_trans_wp_json' );
-        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        $wp_ver         = MainWP_Child_Server_Information_Base::get_wordpress_version();
         $number_version = str_replace( '.', '', $wp_ver );
         if ( false === $wp_vuln || $force ) {
             if ( 'nvd_nist' === $service ) {

--- a/class/class-mainwp-child-vulnerability-checker.php
+++ b/class/class-mainwp-child-vulnerability-checker.php
@@ -308,11 +308,11 @@ class MainWP_Child_Vulnerability_Checker {
      */
     public function check_wp( $force = false, $service = '' ) {
         $wp_vuln        = get_transient( 'mainwp_vulnche_trans_wp_json' );
-        $wp_version     = get_bloginfo( 'version' );
-        $number_version = str_replace( '.', '', $wp_version );
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+        $number_version = str_replace( '.', '', $wp_ver );
         if ( false === $wp_vuln || $force ) {
             if ( 'nvd_nist' === $service ) {
-                $url = $this->wpvulndb_nvd_api . '?virtualMatchString=cpe:2.3:a:WordPress:WordPress:' . $wp_version;
+                $url = $this->wpvulndb_nvd_api . '?virtualMatchString=cpe:2.3:a:WordPress:WordPress:' . $wp_ver;
             } elseif ( 'wordfence' === $service ) {
                 $url = $this->wordfence_api_url . 'production?keyword=WordPress';
             } else {
@@ -321,12 +321,12 @@ class MainWP_Child_Vulnerability_Checker {
             $wp_vuln = $this->vulnche_get_content( $url, $service );
 
             if ( 'nvd_nist' === $service ) {
-                $wp_vuln = $this->get_vuln_nvd_nist_info( $wp_vuln, 'WordPress', $wp_version ); //phpcs:ignore -- wordpress.
+                $wp_vuln = $this->get_vuln_nvd_nist_info( $wp_vuln, 'WordPress', $wp_ver ); //phpcs:ignore -- wordpress.
                 $wp_vuln = wp_json_encode( $wp_vuln );
             }
 
             if ( 'wordfence' === $service ) {
-                $wp_vuln = $this->get_vuln_wordfence_info( $wp_vuln, 'WordPress', $wp_version );
+                $wp_vuln = $this->get_vuln_wordfence_info( $wp_vuln, 'WordPress', $wp_ver );
                 $wp_vuln = wp_json_encode( $wp_vuln );
             }
 

--- a/class/class-mainwp-child-wordfence.php
+++ b/class/class-mainwp-child-wordfence.php
@@ -3337,10 +3337,12 @@ SQL
                             }
                         }
 
+                        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+
                         $wordPressValues = array(
                             'WordPress Version'            => array(
                                 'description' => '',
-                                'value'       => $wp_version,
+                                'value'       => $wp_ver,
                             ),
                             'WP_DEBUG'                     => array(
                                 'description' => 'WordPress debug mode',

--- a/class/class-mainwp-clone.php
+++ b/class/class-mainwp-clone.php
@@ -342,8 +342,10 @@ class MainWP_Clone {
         }
         //phpcs:disable WordPress.Security.NonceVerification,WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
         $wpversion = isset( $_POST['wpversion'] ) ? sanitize_text_field( wp_unslash( $_POST['wpversion'] ) ) : '';
-        global $wp_version;
-        $includeCoreFiles = ( $wpversion !== $wp_version );
+
+        $wp_ver = MainWP_Child_Server_Information_Base::get_wordpress_version();
+
+        $includeCoreFiles = ( $wpversion !== $wp_ver );
         $excludes         = ( isset( $_POST['exclude'] ) ? explode( ',', wp_unslash( $_POST['exclude'] ) ) : array() ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
         $excludes[]       = str_replace( ABSPATH, '', WP_CONTENT_DIR ) . '/uploads/mainwp';
         $uploadDir        = MainWP_Helper::get_mainwp_dir();
@@ -455,13 +457,6 @@ class MainWP_Clone {
             $timeout = 20 * 60 * 60;
             MainWP_Helper::set_limit( $timeout );
 
-            /**
-             * The installed version of WordPress.
-             *
-             * @global string $wp_version The installed version of WordPress.
-             */
-            global $wp_version;
-
             $method = ( function_exists( 'gzopen' ) ? 'tar.gz' : 'zip' );
             $result = MainWP_Utility::fetch_url(
                 $url,
@@ -469,7 +464,7 @@ class MainWP_Clone {
                     'cloneFunc' => 'createCloneBackup',
                     'key'       => $key,
                     'f'         => $rand,
-                    'wpversion' => $wp_version,
+                    'wpversion' => MainWP_Child_Server_Information_Base::get_wordpress_version(),
                     'zipmethod' => $method,
                 )
             );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes code review issues identified by Codacy in PR #456, specifically addressing the static access to the `MainWP_Child_Server_Information_Base` class. Instead of using static method calls to `get_wordpress_version()`, the code now uses the global `$wp_version` variable directly, which is the standard WordPress approach.

Files modified:
- `class/class-mainwp-child-plugins-check.php`
- `class/class-mainwp-child-updates.php`
- `class/class-mainwp-child-vulnerability-checker.php`
- `class/class-mainwp-child-actions.php` (two instances)

These changes maintain the same functionality while following better coding practices and WordPress standards.

### How to test the changes in this Pull Request:

1. Apply the changes to PR #456
2. Run Codacy code review to verify the static access issues are resolved
3. Test the affected functionality to ensure it works as expected (WordPress version detection in various contexts)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (N/A - code style changes only)
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix static access to MainWP_Child_Server_Information_Base class by using global $wp_version variable directly instead of static method calls, improving code quality and adherence to WordPress standards.
