### PR TITLE
Fixed: clear wp fastest cache bug

### DIFF
--- a/class/class-mainwp-child-cache-purge.php
+++ b/class/class-mainwp-child-cache-purge.php
@@ -212,7 +212,7 @@ class MainWP_Child_Cache_Purge { //phpcs:ignore -- NOSONAR - multi methods.
 
         $do_purge = get_option( 'mainwp_child_auto_purge_cache' );
         // If Cache Control is enabled, run the cache purge.
-        if ( 1 === $do_purge || '1' === $do_purge ) {
+        if ( 1 === $do_purge || '1' === $do_purge || 'true' === $bulk ) {
 
             // Set information array.
             $information = array();
@@ -828,7 +828,7 @@ class MainWP_Child_Cache_Purge { //phpcs:ignore -- NOSONAR - multi methods.
         if ( class_exists( 'WpFastestCache' ) ) {
 
             // Clear the Cache after update.
-            do_action( 'wpfc_clear_all_cache' );
+            do_action( 'wpfc_clear_all_cache', true );
 
             // record results.
             update_option( 'mainwp_cache_control_last_purged', time() );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache purging to also occur when the bulk parameter is set to 'true'.
  - Enhanced compatibility with WP Fastest Cache by updating the cache clearing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->