### PR TITLE
Fixed: clear wp fastest cache bug

### DIFF
--- a/class/class-mainwp-child-cache-purge.php
+++ b/class/class-mainwp-child-cache-purge.php
@@ -212,7 +212,7 @@ class MainWP_Child_Cache_Purge { //phpcs:ignore -- NOSONAR - multi methods.
 
         $do_purge = get_option( 'mainwp_child_auto_purge_cache' );
         // If Cache Control is enabled, run the cache purge.
-        if ( 1 === $do_purge || '1' === $do_purge ) {
+        if ( 1 === $do_purge || '1' === $do_purge || 'true' === $bulk ) {
 
             // Set information array.
             $information = array();
@@ -828,7 +828,7 @@ class MainWP_Child_Cache_Purge { //phpcs:ignore -- NOSONAR - multi methods.
         if ( class_exists( 'WpFastestCache' ) ) {
 
             // Clear the Cache after update.
-            do_action( 'wpfc_clear_all_cache' );
+            do_action( 'wpfc_clear_all_cache', true );
 
             // record results.
             update_option( 'mainwp_cache_control_last_purged', time() );

--- a/class/class-mainwp-child.php
+++ b/class/class-mainwp-child.php
@@ -30,7 +30,7 @@ class MainWP_Child {
      *
      * @var string MainWP Child plugin version.
      */
-    public static $version = '5.4.0.9'; // NOSONAR - not IP.
+    public static $version = '5.4.0.10'; // NOSONAR - not IP.
 
     /**
      * Private variable containing the latest MainWP Child update version.

--- a/mainwp-child.php
+++ b/mainwp-child.php
@@ -12,7 +12,7 @@
  * Author: MainWP
  * Author URI: https://mainwp.com
  * Text Domain: mainwp-child
- * Version: 5.4.0.9
+ * Version: 5.4.0.10
  * Requires at least: 5.4
  * Requires PHP: 7.4
  */

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 5.4.0.9
+Stable tag: 5.4.0.10
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -110,6 +110,10 @@ We have an extensive FAQ with more questions and answers [here](https://mainwp.c
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.10 - Maintenance Release - 6-3-2025 =
+
+* Fixed: Restored cache and minified file clearing in Cache Control add-on when using WP Fastest Cache plugin.
 
 = 5.4.0.9 - Maintenance Release - 5-27-2025 =
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache purging to trigger automatically in more scenarios, including when bulk actions are performed.
  - Enhanced compatibility with WP Fastest Cache plugin by updating how cache clearing is invoked.
  - Fixed cache and minified file clearing in the Cache Control add-on when used with WP Fastest Cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->