### PR TITLE
Fixed: incorrect clone upload file size checking

### DIFF
--- a/class/class-mainwp-child.php
+++ b/class/class-mainwp-child.php
@@ -30,7 +30,7 @@ class MainWP_Child {
      *
      * @var string MainWP Child plugin version.
      */
-    public static $version = '5.4.0.10'; // NOSONAR - not IP.
+    public static $version = '5.4.0.11'; // NOSONAR - not IP.
 
     /**
      * Private variable containing the latest MainWP Child update version.

--- a/class/class-mainwp-helper.php
+++ b/class/class-mainwp-helper.php
@@ -569,10 +569,10 @@ class MainWP_Helper { //phpcs:ignore -- NOSONAR - multi methods.
         $last = strtolower( $last );
         switch ( $last ) {
             case 'g':
-                $val *= 1024;
+                $val *= 1024 * 1024 * 1024;
                 break;
             case 'm':
-                $val *= 1024;
+                $val *= 1024 * 1024 ;
                 break;
             case 'k':
                 $val *= 1024;

--- a/mainwp-child.php
+++ b/mainwp-child.php
@@ -12,7 +12,7 @@
  * Author: MainWP
  * Author URI: https://mainwp.com
  * Text Domain: mainwp-child
- * Version: 5.4.0.10
+ * Version: 5.4.0.11
  * Requires at least: 5.4
  * Requires PHP: 7.4
  */

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 5.4.0.10
+Stable tag: 5.4.0.11
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -110,6 +110,12 @@ We have an extensive FAQ with more questions and answers [here](https://mainwp.c
 10. Dashboard Insights
 
 == Changelog ==
+
+
+= 5.4.0.11 - Maintenance Release - 7-8-2025 =
+
+* Fixed: Corrected the upload filesize limit display message on the "Upload/Clone" page to show the accurate maximum file size.
+
 
 = 5.4.0.10 - Maintenance Release - 6-3-2025 =
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the conversion of shorthand byte values for gigabytes ('g') and megabytes ('m') to ensure accurate calculation of byte sizes.
  * Fixed the upload filesize limit display message on the "Upload/Clone" page to show the correct maximum file size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->