### PR TITLE
Add HTTP timeout guards to detect_premium_themesplugins_updates()

### DIFF
--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -37,6 +37,13 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
      */
     private $filterFunction = null;
 
+    /**
+     * Holds the active HTTP timeout guard closure so it can be removed reliably.
+     *
+     * @var \Closure|null
+     */
+    private $http_timeout_guard = null;
+
 
     /**
      * Method get_class_name()
@@ -1120,18 +1127,28 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
             set_site_transient( 'update_plugins', $current );
 
             add_filter( 'pre_site_transient_update_plugins', $this->filterFunction, 99 );
-            $plugins = get_plugin_updates();
-            remove_filter( 'pre_site_transient_update_plugins', $this->filterFunction, 99 );
+            $this->add_http_timeout_guard();
 
-            set_site_transient( 'mainwp_update_plugins_cached', $plugins, DAY_IN_SECONDS );
+            try {
+                $plugins = get_plugin_updates();
+                set_site_transient( 'mainwp_update_plugins_cached', $plugins, DAY_IN_SECONDS );
+            } finally {
+                $this->remove_http_timeout_guard();
+                remove_filter( 'pre_site_transient_update_plugins', $this->filterFunction, 99 );
+            }
         }
 
         if ( isset( $_GET['_detect_themes_updates'] ) && 'yes' === $_GET['_detect_themes_updates'] ) {
             add_filter( 'pre_site_transient_update_themes', $this->filterFunction, 99 );
-            $themes = get_theme_updates();
-            remove_filter( 'pre_site_transient_update_themes', $this->filterFunction, 99 );
+            $this->add_http_timeout_guard();
 
-            set_site_transient( 'mainwp_update_themes_cached', $themes, DAY_IN_SECONDS );
+            try {
+                $themes = get_theme_updates();
+                set_site_transient( 'mainwp_update_themes_cached', $themes, DAY_IN_SECONDS );
+            } finally {
+                $this->remove_http_timeout_guard();
+                remove_filter( 'pre_site_transient_update_themes', $this->filterFunction, 99 );
+            }
         }
 
         $type = isset( $_GET['_request_update_premiums_type'] ) ? sanitize_text_field( wp_unslash( $_GET['_request_update_premiums_type'] ) ) : '';
@@ -1150,6 +1167,66 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
             }
         }
         // phpcs:enable WordPress.WP.AlternativeFunctions
+    }
+
+    /**
+     * Install short-lived HTTP timeout guards before triggering premium update detection.
+     *
+     * Premium update servers can be slow or unreachable, which would otherwise let a single
+     * synchronous detection request hang the entire PHP worker until the LSAPI/FCGI timeout
+     * kicks in (commonly 120s+). The guards cap each outbound HTTP request and its underlying
+     * cURL connect phase to a few seconds, so the detection step degrades gracefully instead
+     * of taking down the request.
+     *
+     * @return void
+     */
+    private function add_http_timeout_guard() {
+        if ( null !== $this->http_timeout_guard ) {
+            return;
+        }
+
+        $this->http_timeout_guard = static function ( $timeout ) {
+            $timeout = (int) $timeout;
+            return ( $timeout > 0 && $timeout < 5 ) ? $timeout : 5;
+        };
+
+        add_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );
+
+        add_action( 'http_api_curl', array( $this, 'cap_curl_connect_timeout' ), PHP_INT_MAX );
+    }
+
+    /**
+     * Remove the HTTP timeout guards installed by add_http_timeout_guard().
+     *
+     * @return void
+     */
+    private function remove_http_timeout_guard() {
+        if ( null === $this->http_timeout_guard ) {
+            return;
+        }
+
+        remove_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );
+        remove_action( 'http_api_curl', array( $this, 'cap_curl_connect_timeout' ), PHP_INT_MAX );
+
+        $this->http_timeout_guard = null;
+    }
+
+    /**
+     * Cap the cURL connect timeout while the HTTP guard is active.
+     *
+     * WordPress does not expose a filter for the cURL connect phase, but a slow or unreachable
+     * remote host can otherwise stall the request well beyond the wp_remote_get() timeout.
+     *
+     * @param resource|\CurlHandle $handle cURL handle, passed by reference by WordPress.
+     *
+     * @return void
+     */
+    public function cap_curl_connect_timeout( $handle ) {
+        if ( ! is_resource( $handle ) && ! ( $handle instanceof \CurlHandle ) ) {
+            return;
+        }
+        // 5 second TCP connect ceiling. Any premium update server slower than this is broken.
+        curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, 5 );
     }
 
     /**

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -40,8 +40,9 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
     /**
      * Timeout ceiling in seconds for premium update discovery HTTP calls.
      *
-     * Applied to both the wp_remote_* request timeout and the underlying cURL connect phase
-     * while detect_premium_themesplugins_updates() is running.
+     * Applied to the http_request_timeout filter while detect_premium_themesplugins_updates()
+     * is running, so that a single slow or unreachable premium update server cannot stall the
+     * entire PHP worker.
      */
     private const PREMIUM_UPDATE_HTTP_TIMEOUT = 5.0;
 
@@ -1178,12 +1179,12 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
     }
 
     /**
-     * Install short-lived HTTP timeout guards before triggering premium update detection.
+     * Install a short-lived HTTP timeout guard before triggering premium update detection.
      *
      * Premium update servers can be slow or unreachable, which would otherwise let a single
      * synchronous detection request hang the entire PHP worker until the LSAPI/FCGI timeout
-     * kicks in (commonly 120s+). The guards cap each outbound HTTP request and its underlying
-     * cURL connect phase to a few seconds, so the detection step degrades gracefully instead
+     * kicks in (commonly 120s+). The guard caps each outbound HTTP request to a few seconds
+     * via the http_request_timeout filter, so the detection step degrades gracefully instead
      * of taking down the request.
      *
      * @return void
@@ -1199,12 +1200,10 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         };
 
         add_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );
-
-        add_action( 'http_api_curl', array( $this, 'cap_curl_connect_timeout' ), PHP_INT_MAX );
     }
 
     /**
-     * Remove the HTTP timeout guards installed by add_http_timeout_guard().
+     * Remove the HTTP timeout guard installed by add_http_timeout_guard().
      *
      * @return void
      */
@@ -1214,28 +1213,8 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         }
 
         remove_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );
-        remove_action( 'http_api_curl', array( $this, 'cap_curl_connect_timeout' ), PHP_INT_MAX );
 
         $this->http_timeout_guard = null;
-    }
-
-    /**
-     * Cap the cURL connect timeout while the HTTP guard is active.
-     *
-     * WordPress does not expose a filter for the cURL connect phase, but a slow or unreachable
-     * remote host can otherwise stall the request well beyond the wp_remote_get() timeout.
-     *
-     * @param resource|\CurlHandle $handle cURL handle, passed by reference by WordPress.
-     *
-     * @return void
-     */
-    public function cap_curl_connect_timeout( $handle ) {
-        if ( ! is_resource( $handle ) && ! ( $handle instanceof \CurlHandle ) ) {
-            return;
-        }
-        // TCP connect ceiling. Any premium update server slower than this is broken.
-        // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- http_api_curl is the WordPress-provided hook for modifying the cURL handle that WordPress itself uses; there is no wp_remote_* equivalent for CURLOPT_CONNECTTIMEOUT.
-        curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, (int) self::PREMIUM_UPDATE_HTTP_TIMEOUT );
     }
 
     /**

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -38,6 +38,14 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
     private $filterFunction = null;
 
     /**
+     * Timeout ceiling in seconds for premium update discovery HTTP calls.
+     *
+     * Applied to both the wp_remote_* request timeout and the underlying cURL connect phase
+     * while detect_premium_themesplugins_updates() is running.
+     */
+    private const PREMIUM_UPDATE_HTTP_TIMEOUT = 5.0;
+
+    /**
      * Holds the active HTTP timeout guard closure so it can be removed reliably.
      *
      * @var \Closure|null
@@ -1186,8 +1194,8 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         }
 
         $this->http_timeout_guard = static function ( $timeout ) {
-            $timeout = is_numeric( $timeout ) ? (float) $timeout : 5.0;
-            return ( $timeout > 0 ) ? min( $timeout, 5.0 ) : 5.0;
+            $timeout = is_numeric( $timeout ) ? (float) $timeout : self::PREMIUM_UPDATE_HTTP_TIMEOUT;
+            return ( $timeout > 0 ) ? min( $timeout, self::PREMIUM_UPDATE_HTTP_TIMEOUT ) : self::PREMIUM_UPDATE_HTTP_TIMEOUT;
         };
 
         add_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );
@@ -1225,9 +1233,9 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         if ( ! is_resource( $handle ) && ! ( $handle instanceof \CurlHandle ) ) {
             return;
         }
-        // 5 second TCP connect ceiling. Any premium update server slower than this is broken.
+        // TCP connect ceiling. Any premium update server slower than this is broken.
         // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- http_api_curl is the WordPress-provided hook for modifying the cURL handle that WordPress itself uses; there is no wp_remote_* equivalent for CURLOPT_CONNECTTIMEOUT.
-        curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, 5 );
+        curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, (int) self::PREMIUM_UPDATE_HTTP_TIMEOUT );
     }
 
     /**

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -1186,8 +1186,8 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
         }
 
         $this->http_timeout_guard = static function ( $timeout ) {
-            $timeout = (int) $timeout;
-            return ( $timeout > 0 && $timeout < 5 ) ? $timeout : 5;
+            $timeout = is_numeric( $timeout ) ? (float) $timeout : 5.0;
+            return ( $timeout > 0 ) ? min( $timeout, 5.0 ) : 5.0;
         };
 
         add_filter( 'http_request_timeout', $this->http_timeout_guard, PHP_INT_MAX );

--- a/class/class-mainwp-child-updates.php
+++ b/class/class-mainwp-child-updates.php
@@ -1226,6 +1226,7 @@ class MainWP_Child_Updates { //phpcs:ignore -- NOSONAR - multi methods.
             return;
         }
         // 5 second TCP connect ceiling. Any premium update server slower than this is broken.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_setopt -- http_api_curl is the WordPress-provided hook for modifying the cURL handle that WordPress itself uses; there is no wp_remote_* equivalent for CURLOPT_CONNECTTIMEOUT.
         curl_setopt( $handle, CURLOPT_CONNECTTIMEOUT, 5 );
     }
 


### PR DESCRIPTION
# Add HTTP timeout guards to `detect_premium_themesplugins_updates()`

## Problem

`MainWP_Child_Updates::detect_premium_themesplugins_updates()` is hooked to `pre_current_active_plugins` and `core_upgrade_preamble`. When the MainWP Dashboard syncs a child site, it fires requests like `GET /wp-admin/plugins.php?_detect_plugins_updates=yes`, which causes this method to call `get_plugin_updates()` (and `get_theme_updates()` for the themes branch). Both functions trigger synchronous outbound HTTP requests to wordpress.org and to every premium plugin/theme update server registered on the site.

If a single premium update server is slow or unreachable, the entire PHP worker stalls until the FastCGI/LSAPI timeout (commonly 120s+) kills it. The Dashboard then logs a sync failure for the site, even though every other plugin would have responded just fine.

This was reproducible on a production LiteSpeed/CloudLinux setup. The relevant LSAPI log lines look like this:

```
Connection idle time: 121 while in state: 7 stream flag: 0x21400,close!
Content len: 0, Request line: 'GET /wp-admin/plugins.php?_detect_plugins_updates=yes HTTP/1.1'
Lsapi connection state: 4, ... req sent for 121 seconds, Total processing time: 121.
abort request..., code: 4
Abort request processing by PID:..., kill: 0, begin time: 121, sent time: 121, req processed: 1
```

There are two underlying issues:

1. **No HTTP timeout protection.** WordPress' default `wp_remote_get()` timeout is 5 seconds, but third-party plugins regularly raise it via the `http_request_timeout` filter, and the cURL TCP connect phase has its own timeout that WordPress does not expose at all. A single misbehaving update server can therefore block the worker for far longer than five seconds.
2. **Filters leak on exception.** If `get_plugin_updates()` or `get_theme_updates()` throws, the `pre_site_transient_update_plugins` / `pre_site_transient_update_themes` filter remains attached for the rest of the request and contaminates downstream code that reads those transients.

## Fix

This PR wraps the two detection branches in try/finally so the transient filters are always removed even if an exception is thrown, and installs a short-lived HTTP timeout guard around the get_plugin_updates() / get_theme_updates() calls. The guard hooks http_request_timeout at PHP_INT_MAX priority and caps each outbound request at 5 seconds. The filter only ever lowers the value (via min()), never raises it, so plugins that legitimately need a shorter timeout are unaffected. Both the guard and the transient filters are removed in the finally block, so they only affect the detection step itself and never bleed into other HTTP traffic during the same request.
The result is that detection of premium plugin/theme updates degrades gracefully when a remote server is slow: that single update is missed for the current sync (and will be picked up on the next one), instead of taking down the entire MainWP Dashboard sync for the site.

## Compatibility

- No changes to public API or hook signatures.
- No new dependencies.
- PHP 7.4+ compatible (uses `try`/`finally`, anonymous functions, no `match`/enums/readonly).
- Five seconds is generous for any working update server. WordPress' own default for `wp_remote_get()` is also five seconds, so the cap is not stricter than core defaults.

## Files changed

class/class-mainwp-child-updates.php

New PREMIUM_UPDATE_HTTP_TIMEOUT class constant.
New private property $http_timeout_guard to hold the active closure for reliable removal.
detect_premium_themesplugins_updates() plugin and theme branches wrapped in try/finally with the new HTTP timeout guard helpers.
New private helpers add_http_timeout_guard() / remove_http_timeout_guard().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Premium plugin and theme update checks now enforce a short (5s) network timeout to avoid long hangs.
  * Temporary timeout guards and related cleanup are always removed, even if discovery fails, preventing stale cached state.
  * Update discovery is more robust and reliable, reducing the risk of failed or inconsistent update detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->